### PR TITLE
Bump sdk to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,9 +1509,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opensecret"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907713724b6c28098a88c7bbc2e88d01e9b95de3b1e3aec59c8479562fae89ed"
+checksum = "8cab60da21f06cccb63bec26affb60d0da0d1324c4a822a4fb1b99406fbcbf45"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 # OpenSecret SDK 
-opensecret = "0.2.0"
+opensecret = "0.2.1"
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenSecret SDK dependency to version 0.2.1 for improved stability and compatibility.
  * No changes to public APIs or user-facing functionality.
* **Style**
  * Minor formatting cleanup (end-of-file newline) with no behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->