### PR TITLE
feat: add OpenAI-compatible embeddings endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,9 +1508,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opensecret"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e2b23865f980073312a3c7662f9b9099eaeafec762d2ef958e098493770203"
+checksum = "68faccec2c0b03eefcc94985c01730d1f50b5ff98684c1afec367ba8301b144c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 # OpenSecret SDK 
-opensecret = "0.2.3"
+opensecret = "0.2.7"
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod config;
 pub mod proxy;
 
 pub use config::{Config, OpenAIError, OpenAIErrorDetails};
-use proxy::{create_chat_completion, health_check, list_models, ProxyState};
+use proxy::{create_chat_completion, create_embeddings, health_check, list_models, ProxyState};
 
 use axum::{
     http::Method,
@@ -28,6 +28,7 @@ pub fn create_app(config: Config) -> Router {
         // OpenAI-compatible endpoints
         .route("/v1/models", get(list_models))
         .route("/v1/chat/completions", post(create_chat_completion))
+        .route("/v1/embeddings", post(create_embeddings))
         .with_state(state)
         .layer(
             ServiceBuilder::new().layer(


### PR DESCRIPTION
## Summary

Adds support for text embeddings via the OpenAI-compatible `/v1/embeddings` endpoint, proxying to the OpenSecret backend with E2EE via TEE attestation.

## Changes

- Update opensecret SDK from 0.2.3 to 0.2.7 (includes embeddings support)
- Add `create_embeddings` handler in `proxy.rs` following the same pattern as chat completions
- Register `/v1/embeddings` POST route in `lib.rs`

## API Format

Follows standard OpenAI embeddings API:
```json
// Request
POST /v1/embeddings
{
  "input": "text to embed" | ["text1", "text2"],
  "model": "nomic-embed-text"
}

// Response
{
  "object": "list",
  "data": [{"object": "embedding", "index": 0, "embedding": [...768 floats...]}],
  "model": "nomic-embed-text",
  "usage": {"prompt_tokens": N, "total_tokens": N}
}
```

## Testing

Tested against dev environment with both single and multiple input embeddings - working correctly with 768-dimension vectors from `nomic-embed-text` model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/v1/embeddings` endpoint to the API, enabling users to generate embeddings for text inputs in addition to existing chat completion and model listing capabilities.

* **Dependencies**
  * Updated core dependency to a newer version for improved stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->