### PR TITLE
fix: update time and bytes crates for RUSTSEC-2026-0009 and RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"


### PR DESCRIPTION
## Summary

Updates transitive dependencies to resolve two security advisories:

- **RUSTSEC-2026-0009**: `time` 0.3.41 -> 0.3.47 -- Denial of service via stack exhaustion when parsing RFC 2822 formatted input.
- **RUSTSEC-2026-0007**: `bytes` 1.10.1 -> 1.11.1 -- Integer overflow in `BytesMut::reserve` leading to out-of-bounds memory access in release builds (CVE-2026-25541).

## Changes

- `Cargo.lock` only -- no source code changes.

## Testing

- `cargo build` -- clean
- `cargo test` -- all passing
- `cargo clippy -- -D warnings` -- clean

Closes #9