### PR TITLE
feat: add OpenClaw plugin for seamless maple-proxy integration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,9 @@
           gcc
           clang
           libclang
+
+          # TypeScript / OpenClaw plugin
+          nodejs_22
           
           # Useful tools
           jq

--- a/justfile
+++ b/justfile
@@ -256,3 +256,51 @@ ghcr-pull tag="latest":
     @echo "📥 Pulling from GitHub Container Registry..."
     @{{container}} pull ghcr.io/opensecretcloud/maple-proxy:{{tag}}
     @echo "✅ Pulled ghcr.io/opensecretcloud/maple-proxy:{{tag}}"
+
+# === OpenClaw Plugin ===
+
+# Install plugin dependencies
+plugin-install:
+    @echo "📦 Installing plugin dependencies..."
+    @cd openclaw-plugin && npm install
+    @echo "✅ Plugin dependencies installed"
+
+# Build plugin (TypeScript -> JS)
+plugin-build:
+    @echo "🔨 Building OpenClaw plugin..."
+    @cd openclaw-plugin && npm run build
+    @echo "✅ Plugin built"
+
+# Lint plugin
+plugin-lint:
+    @echo "🔍 Linting plugin..."
+    @cd openclaw-plugin && npm run lint
+    @echo "✅ Plugin linted"
+
+# Test plugin
+plugin-test:
+    @echo "🧪 Testing plugin..."
+    @cd openclaw-plugin && npm test
+    @echo "✅ Plugin tests passed"
+
+# Check all (Rust + plugin)
+check-all: check plugin-lint plugin-test
+    @echo "✅ All checks passed (Rust + Plugin)"
+
+# Link plugin locally for OpenClaw development
+plugin-link:
+    @echo "🔗 Linking plugin to OpenClaw extensions..."
+    @openclaw plugins install -l ./openclaw-plugin
+    @echo "✅ Plugin linked"
+
+# Pack plugin for npm publishing
+plugin-pack:
+    @echo "📦 Packing plugin for npm..."
+    @cd openclaw-plugin && npm pack
+    @echo "✅ Plugin packed"
+
+# Publish plugin to npm
+plugin-publish:
+    @echo "🚀 Publishing plugin to npm..."
+    @cd openclaw-plugin && npm publish --access public
+    @echo "✅ Plugin published"

--- a/openclaw-plugin/.gitignore
+++ b/openclaw-plugin/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tgz

--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -53,7 +53,10 @@ Add a `maple` provider so OpenClaw can route requests to the local proxy (defaul
         "api": "openai-completions",
         "models": [
           { "id": "kimi-k2-5", "name": "Kimi K2.5 (recommended)" },
-          { "id": "llama-3.3-70b", "name": "Llama 3.3 70B" }
+          { "id": "deepseek-r1-0528", "name": "DeepSeek R1" },
+          { "id": "gpt-oss-120b", "name": "GPT-OSS 120B" },
+          { "id": "llama-3.3-70b", "name": "Llama 3.3 70B" },
+          { "id": "qwen3-vl-30b", "name": "Qwen3 VL 30B" }
         ]
       }
     }
@@ -73,7 +76,10 @@ If you have an `agents.defaults.models` section in your config, add the maple mo
     "defaults": {
       "models": {
         "maple/kimi-k2-5": {},
-        "maple/llama-3.3-70b": {}
+        "maple/deepseek-r1-0528": {},
+        "maple/gpt-oss-120b": {},
+        "maple/llama-3.3-70b": {},
+        "maple/qwen3-vl-30b": {}
       }
     }
   }
@@ -93,7 +99,10 @@ Plugin config changes always require a full gateway restart. Model and provider 
 Use maple models by prefixing with `maple/`:
 
 - `maple/kimi-k2-5` (recommended)
+- `maple/deepseek-r1-0528`
+- `maple/gpt-oss-120b`
 - `maple/llama-3.3-70b`
+- `maple/qwen3-vl-30b`
 
 The plugin also registers a `maple_proxy_status` tool that shows the proxy's health, port, version, and available endpoints. If the plugin isn't configured yet, the tool returns setup instructions.
 

--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -1,0 +1,180 @@
+# @opensecret/maple-openclaw-plugin
+
+OpenClaw plugin that automatically downloads, configures, and runs [maple-proxy](https://github.com/OpenSecretCloud/maple-proxy) as a background service. All AI inference runs inside Maple's TEE (Trusted Execution Environment) secure enclaves.
+
+## Install
+
+```bash
+openclaw plugins install @opensecret/maple-openclaw-plugin
+```
+
+## Setup
+
+### 1. Configure the plugin
+
+Set your Maple API key in `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "maple-openclaw-plugin": {
+        "enabled": true,
+        "config": {
+          "apiKey": "YOUR_MAPLE_API_KEY"
+        }
+      }
+    }
+  }
+}
+```
+
+### 2. Add the Maple provider
+
+Add a `maple` provider so OpenClaw can route requests to the local proxy (default port **8787**):
+
+```json
+{
+  "models": {
+    "providers": {
+      "maple": {
+        "baseUrl": "http://127.0.0.1:8787/v1",
+        "apiKey": "YOUR_MAPLE_API_KEY",
+        "api": "openai-completions",
+        "models": [
+          { "id": "kimi-k2-5", "name": "Kimi K2.5 (recommended)" },
+          { "id": "llama-3.3-70b", "name": "Llama 3.3 70B" }
+        ]
+      }
+    }
+  }
+}
+```
+
+Use the same Maple API key in both places. To discover all available models, call `GET http://127.0.0.1:8787/v1/models` after startup.
+
+### 3. Add models to the allowlist (if applicable)
+
+If you have an `agents.defaults.models` section in your config, add the maple models you want. If you don't have this section, skip this step -- all models are allowed by default.
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "models": {
+        "maple/kimi-k2-5": {},
+        "maple/llama-3.3-70b": {}
+      }
+    }
+  }
+}
+```
+
+### 4. Restart the gateway
+
+```bash
+systemctl restart openclaw.service
+```
+
+Plugin config changes always require a full gateway restart. Model and provider config changes hot-apply without a restart.
+
+## Usage
+
+Use maple models by prefixing with `maple/`:
+
+- `maple/kimi-k2-5` (recommended)
+- `maple/llama-3.3-70b`
+
+The plugin also registers a `maple_proxy_status` tool that shows the proxy's health, port, version, and available endpoints. If the plugin isn't configured yet, the tool returns setup instructions.
+
+## Embeddings & Memory Search
+
+maple-proxy serves an OpenAI-compatible embeddings endpoint using the `nomic-embed-text` model. You can use this for OpenClaw's memory search so embeddings are generated inside the TEE -- no cloud embedding provider needed.
+
+### Enable the memory-core plugin
+
+The `memory_search` and `memory_get` tools come from OpenClaw's `memory-core` plugin. It ships as a stock plugin but **must be explicitly enabled**:
+
+```json
+{
+  "plugins": {
+    "allow": ["memory-core"],
+    "entries": {
+      "memory-core": {
+        "enabled": true
+      }
+    }
+  }
+}
+```
+
+### Configure memorySearch
+
+> **Important**: The model field must be `nomic-embed-text` (without a `maple/` prefix). Using `maple/nomic-embed-text` will cause 400 errors.
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "memorySearch": {
+        "enabled": true,
+        "provider": "openai",
+        "model": "nomic-embed-text",
+        "remote": {
+          "baseUrl": "http://127.0.0.1:8787/v1/",
+          "apiKey": "YOUR_MAPLE_API_KEY"
+        }
+      }
+    }
+  }
+}
+```
+
+### Restart and reindex
+
+```bash
+systemctl restart openclaw.service
+openclaw memory index --verbose
+openclaw memory status --deep
+```
+
+The status output should show **Embeddings: available** and **Vector: ready**.
+
+### Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| "memory slot plugin not found" | `memory-core` not enabled | Add to `plugins.allow` and `plugins.entries`, restart |
+| Embeddings 400 error | Model has provider prefix | Change `maple/nomic-embed-text` to `nomic-embed-text` |
+| Embeddings 401 error | Wrong API key | Check the key is the actual value, not a placeholder |
+| "Batch: disabled" in status | Too many embedding failures | Fix config, restart to reset failure counter |
+| Only some files indexed | Embeddings were failing during indexing | Fix config, restart, run `openclaw memory index --verbose` |
+
+## Plugin Config Options
+
+| Option | Default | Description |
+|---|---|---|
+| `apiKey` | (required) | Your Maple API key |
+| `port` | `8787` | Local port for the proxy |
+| `backendUrl` | `https://enclave.trymaple.ai` | Maple TEE backend URL |
+| `debug` | `false` | Enable debug logging |
+| `version` | (latest) | Pin to a specific maple-proxy version |
+
+## Updating
+
+```bash
+openclaw plugins update maple-openclaw-plugin
+```
+
+> **Note**: `openclaw plugins update` works for stable releases. To move between beta versions, reinstall with the full version: `openclaw plugins install @opensecret/maple-openclaw-plugin@0.1.0-beta.4`
+
+## Direct API Access
+
+- `GET http://127.0.0.1:8787/v1/models` -- List available models
+- `POST http://127.0.0.1:8787/v1/chat/completions` -- Chat completions (streaming and non-streaming)
+- `POST http://127.0.0.1:8787/v1/embeddings` -- Generate embeddings (model: `nomic-embed-text`)
+- `GET http://127.0.0.1:8787/health` -- Health check
+
+## License
+
+MIT

--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -2,13 +2,23 @@
 
 OpenClaw plugin that automatically downloads, configures, and runs [maple-proxy](https://github.com/OpenSecretCloud/maple-proxy) as a background service. All AI inference runs inside Maple's TEE (Trusted Execution Environment) secure enclaves.
 
-## Install
+## Quick Start (Recommended)
+
+Install the plugin and let your agent handle the rest:
 
 ```bash
 openclaw plugins install @opensecret/maple-openclaw-plugin
 ```
 
-## Setup
+Then tell your agent:
+
+> Install and configure maple-proxy with my API key: `YOUR_MAPLE_API_KEY`
+
+The plugin bundles a skill that teaches the agent how to set up the maple provider, configure models, and enable embeddings. After a gateway restart, the agent will have all the context it needs from the skill to complete the setup. If the plugin isn't configured yet, the `maple_proxy_status` tool also returns step-by-step instructions.
+
+## Manual Setup
+
+If you prefer to configure everything yourself, follow these steps after installing the plugin.
 
 ### 1. Configure the plugin
 

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -6,6 +6,7 @@ interface PluginConfig {
   port?: number;
   backendUrl?: string;
   debug?: boolean;
+  version?: string;
 }
 
 interface PluginApi {
@@ -40,7 +41,10 @@ export default function register(api: PluginApi) {
       }
 
       try {
-        const { binaryPath, version } = await ensureBinary(api.logger);
+        const { binaryPath, version } = await ensureBinary(
+          api.logger,
+          pluginConfig.version
+        );
         api.logger.info(`maple-proxy binary: ${version} at ${binaryPath}`);
 
         proxy = await startProxy(

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -1,0 +1,71 @@
+import { ensureBinary } from "./lib/downloader.js";
+import { startProxy, type RunningProxy } from "./lib/process.js";
+
+interface PluginConfig {
+  apiKey: string;
+  port?: number;
+  backendUrl?: string;
+  debug?: boolean;
+}
+
+interface PluginApi {
+  config: { plugins: { entries: Record<string, { config: PluginConfig }> } };
+  logger: { info: (msg: string) => void; error: (msg: string) => void };
+  registerService: (service: {
+    id: string;
+    start: () => Promise<void>;
+    stop: () => Promise<void>;
+  }) => void;
+}
+
+export const id = "maple-proxy-openclaw-plugin";
+export const name = "Maple Proxy";
+
+export default function register(api: PluginApi) {
+  let proxy: RunningProxy | null = null;
+
+  api.registerService({
+    id: "maple-proxy-service",
+
+    async start() {
+      const pluginConfig =
+        api.config.plugins.entries["maple-proxy-openclaw-plugin"]?.config;
+
+      if (!pluginConfig?.apiKey) {
+        api.logger.error(
+          "maple-proxy-openclaw-plugin: no apiKey configured. " +
+            'Set plugins.entries["maple-proxy-openclaw-plugin"].config.apiKey in openclaw.json'
+        );
+        return;
+      }
+
+      try {
+        const { binaryPath, version } = await ensureBinary(api.logger);
+        api.logger.info(`maple-proxy binary: ${version} at ${binaryPath}`);
+
+        proxy = await startProxy(
+          {
+            binaryPath,
+            apiKey: pluginConfig.apiKey,
+            port: pluginConfig.port,
+            backendUrl: pluginConfig.backendUrl,
+            debug: pluginConfig.debug,
+          },
+          api.logger
+        );
+      } catch (err) {
+        api.logger.error(
+          `maple-proxy-openclaw-plugin: failed to start: ${err instanceof Error ? err.message : err}`
+        );
+      }
+    },
+
+    async stop() {
+      if (proxy) {
+        api.logger.info("Stopping maple-proxy...");
+        proxy.kill();
+        proxy = null;
+      }
+    },
+  });
+}

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -141,7 +141,7 @@ export default function register(api: PluginApi) {
 
         api.logger.info(
           `maple-proxy is OpenAI-compatible at http://127.0.0.1:${proxy.port}/v1 ` +
-            `-- configure as vLLM provider or use directly`
+            `-- configure as maple provider or use directly`
         );
       } catch (err) {
         api.logger.error(

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -50,6 +50,29 @@ export default function register(api: PluginApi) {
       properties: {},
     },
     async execute() {
+      const pluginConfig =
+        api.config.plugins.entries[PLUGIN_CONFIG_KEY]?.config;
+
+      if (!pluginConfig?.apiKey) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                running: false,
+                error: "maple-proxy is not configured",
+                setup: {
+                  step1: 'Set your Maple API key: plugins.entries["maple-openclaw-plugin"].config.apiKey',
+                  step2: "Add a maple provider to models.providers with baseUrl http://127.0.0.1:8787/v1 and your Maple API key",
+                  step3: "If you have agents.defaults.models, add the maple models (e.g. maple/kimi-k2-5)",
+                  step4: "Restart the gateway",
+                },
+              }),
+            },
+          ],
+        };
+      }
+
       if (!proxy) {
         return {
           content: [
@@ -57,7 +80,7 @@ export default function register(api: PluginApi) {
               type: "text",
               text: JSON.stringify({
                 running: false,
-                error: "maple-proxy is not running",
+                error: "maple-proxy is not running. The API key is configured but the service failed to start. Check gateway logs for details.",
               }),
             },
           ],

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -96,6 +96,12 @@ export default function register(api: PluginApi) {
     id: "maple-proxy-service",
 
     async start() {
+      if (proxy) {
+        api.logger.info("Stopping existing maple-proxy before restart...");
+        proxy.kill();
+        proxy = null;
+      }
+
       const pluginConfig =
         api.config.plugins.entries[PLUGIN_CONFIG_KEY]?.config;
 

--- a/openclaw-plugin/lib/downloader.test.ts
+++ b/openclaw-plugin/lib/downloader.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { compareVersionsDesc } from "./downloader.js";
+
+describe("compareVersionsDesc", () => {
+  it("sorts simple versions in descending order", () => {
+    const input = ["v0.1.0", "v0.2.0", "v0.1.5"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, ["v0.2.0", "v0.1.5", "v0.1.0"]);
+  });
+
+  it("handles v0.9.0 vs v0.10.0 correctly (not lexicographic)", () => {
+    const input = ["v0.9.0", "v0.10.0", "v0.2.0"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, ["v0.10.0", "v0.9.0", "v0.2.0"]);
+  });
+
+  it("handles major version differences", () => {
+    const input = ["v1.0.0", "v2.0.0", "v0.9.0"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, ["v2.0.0", "v1.0.0", "v0.9.0"]);
+  });
+
+  it("handles patch version differences", () => {
+    const input = ["v0.1.1", "v0.1.3", "v0.1.2"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, ["v0.1.3", "v0.1.2", "v0.1.1"]);
+  });
+
+  it("handles double-digit version components", () => {
+    const input = ["v1.2.3", "v1.12.0", "v1.2.30"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, ["v1.12.0", "v1.2.30", "v1.2.3"]);
+  });
+
+  it("keeps equal versions stable", () => {
+    const input = ["v0.1.6", "v0.1.6"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, ["v0.1.6", "v0.1.6"]);
+  });
+
+  it("handles single element", () => {
+    const input = ["v0.1.0"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, ["v0.1.0"]);
+  });
+
+  it("handles empty array", () => {
+    const input: string[] = [];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, []);
+  });
+
+  it("handles realistic release sequence", () => {
+    const input = ["v0.1.0", "v0.1.6", "v0.1.5", "v0.2.0", "v0.1.10"];
+    const result = [...input].sort(compareVersionsDesc);
+    assert.deepStrictEqual(result, [
+      "v0.2.0",
+      "v0.1.10",
+      "v0.1.6",
+      "v0.1.5",
+      "v0.1.0",
+    ]);
+  });
+});

--- a/openclaw-plugin/lib/downloader.ts
+++ b/openclaw-plugin/lib/downloader.ts
@@ -43,10 +43,16 @@ async function verifyChecksum(
 ): Promise<void> {
   const res = await fetch(checksumUrl, { redirect: "follow" });
   if (!res.ok) {
-    logger.info(
-      `Warning: checksum file not available (${res.status}), skipping verification for ${path.basename(filePath)}`
+    if (res.status === 404) {
+      logger.info(
+        `Warning: checksum file not found (404), skipping verification for ${path.basename(filePath)}`
+      );
+      return;
+    }
+    throw new Error(
+      `Failed to fetch checksum for ${path.basename(filePath)}: ${res.status} ${res.statusText}. ` +
+        `This may indicate GitHub rate limiting or a server error.`
     );
-    return;
   }
 
   const expectedLine = (await res.text()).trim();

--- a/openclaw-plugin/lib/downloader.ts
+++ b/openclaw-plugin/lib/downloader.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  getArtifact,
+  getReleaseUrl,
+  getChecksumUrl,
+  getBinaryPath,
+  getCacheDir,
+  getLatestVersion,
+} from "./platform.js";
+
+const execFileAsync = promisify(execFile);
+
+async function downloadFile(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`Download failed: ${res.status} ${res.statusText} (${url})`);
+  }
+  const buffer = Buffer.from(await res.arrayBuffer());
+  await fsp.writeFile(dest, buffer);
+}
+
+async function verifyChecksum(filePath: string, checksumUrl: string): Promise<void> {
+  const res = await fetch(checksumUrl, { redirect: "follow" });
+  if (!res.ok) {
+    // Checksum file may not exist for older releases; warn but don't fail
+    return;
+  }
+
+  const expectedLine = (await res.text()).trim();
+  // Format: "<hash>  <filename>" or just "<hash>"
+  const expectedHash = expectedLine.split(/\s+/)[0];
+
+  const { createHash } = await import("node:crypto");
+  const fileBuffer = await fsp.readFile(filePath);
+  const actualHash = createHash("sha256").update(fileBuffer).digest("hex");
+
+  if (actualHash !== expectedHash) {
+    await fsp.unlink(filePath);
+    throw new Error(
+      `Checksum mismatch for ${path.basename(filePath)}: ` +
+        `expected ${expectedHash}, got ${actualHash}`
+    );
+  }
+}
+
+async function extractTarGz(archivePath: string, destDir: string): Promise<void> {
+  await execFileAsync("tar", ["-xzf", archivePath, "-C", destDir]);
+}
+
+async function extractZip(archivePath: string, destDir: string): Promise<void> {
+  if (process.platform === "win32") {
+    await execFileAsync("powershell", [
+      "-Command",
+      `Expand-Archive -Path '${archivePath}' -DestinationPath '${destDir}' -Force`,
+    ]);
+  } else {
+    await execFileAsync("unzip", ["-o", archivePath, "-d", destDir]);
+  }
+}
+
+export interface DownloadResult {
+  binaryPath: string;
+  version: string;
+}
+
+export async function ensureBinary(logger: { info: (msg: string) => void }): Promise<DownloadResult> {
+  const version = await getLatestVersion();
+  const binaryPath = getBinaryPath(version);
+
+  if (fs.existsSync(binaryPath)) {
+    logger.info(`maple-proxy ${version} already cached at ${binaryPath}`);
+    return { binaryPath, version };
+  }
+
+  const artifact = getArtifact();
+  const cacheDir = getCacheDir();
+  const versionDir = path.join(cacheDir, version);
+  await fsp.mkdir(versionDir, { recursive: true });
+
+  const ext = artifact.archiveType === "zip" ? "zip" : "tar.gz";
+  const archivePath = path.join(versionDir, `${artifact.name}.${ext}`);
+
+  logger.info(`Downloading maple-proxy ${version} for ${artifact.name}...`);
+  const releaseUrl = getReleaseUrl(version, artifact);
+  await downloadFile(releaseUrl, archivePath);
+
+  const checksumUrl = getChecksumUrl(version, artifact);
+  await verifyChecksum(archivePath, checksumUrl);
+
+  logger.info(`Extracting to ${versionDir}...`);
+  if (artifact.archiveType === "zip") {
+    await extractZip(archivePath, versionDir);
+  } else {
+    await extractTarGz(archivePath, versionDir);
+  }
+
+  await fsp.unlink(archivePath);
+
+  if (process.platform !== "win32") {
+    await fsp.chmod(binaryPath, 0o755);
+  }
+
+  logger.info(`maple-proxy ${version} ready at ${binaryPath}`);
+  return { binaryPath, version };
+}

--- a/openclaw-plugin/lib/platform.ts
+++ b/openclaw-plugin/lib/platform.ts
@@ -1,0 +1,66 @@
+import os from "node:os";
+import path from "node:path";
+
+const GITHUB_REPO = "OpenSecretCloud/maple-proxy";
+
+export interface PlatformArtifact {
+  name: string;
+  archiveType: "tar.gz" | "zip";
+}
+
+export function getArtifact(): PlatformArtifact {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  if (platform === "linux" && arch === "x64") {
+    return { name: "maple-proxy-linux-x86_64", archiveType: "tar.gz" };
+  }
+  if (platform === "linux" && arch === "arm64") {
+    return { name: "maple-proxy-linux-aarch64", archiveType: "tar.gz" };
+  }
+  if (platform === "darwin" && arch === "arm64") {
+    return { name: "maple-proxy-macos-aarch64", archiveType: "tar.gz" };
+  }
+  if (platform === "win32" && arch === "x64") {
+    return { name: "maple-proxy-windows-x86_64", archiveType: "zip" };
+  }
+
+  throw new Error(
+    `Unsupported platform: ${platform}/${arch}. ` +
+      `Supported: linux/x64, linux/arm64, darwin/arm64, win32/x64`
+  );
+}
+
+export function getReleaseUrl(version: string, artifact: PlatformArtifact): string {
+  const ext = artifact.archiveType === "zip" ? "zip" : "tar.gz";
+  return `https://github.com/${GITHUB_REPO}/releases/download/${version}/${artifact.name}.${ext}`;
+}
+
+export function getChecksumUrl(version: string, artifact: PlatformArtifact): string {
+  const ext = artifact.archiveType === "zip" ? "zip" : "tar.gz";
+  return `https://github.com/${GITHUB_REPO}/releases/download/${version}/${artifact.name}.${ext}.sha256`;
+}
+
+export function getCacheDir(): string {
+  return path.join(os.homedir(), ".openclaw", "tools", "maple-proxy");
+}
+
+export function getBinaryName(): string {
+  return os.platform() === "win32" ? "maple-proxy.exe" : "maple-proxy";
+}
+
+export function getBinaryPath(version: string): string {
+  return path.join(getCacheDir(), version, getBinaryName());
+}
+
+export async function getLatestVersion(): Promise<string> {
+  const url = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+  const res = await fetch(url, {
+    headers: { Accept: "application/vnd.github.v3+json" },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch latest release: ${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { tag_name: string };
+  return data.tag_name;
+}

--- a/openclaw-plugin/lib/process.ts
+++ b/openclaw-plugin/lib/process.ts
@@ -153,7 +153,7 @@ export async function startProxy(
                 child.kill("SIGKILL");
               }
             }
-          }, delay);
+          }, delay).unref();
         } else {
           logger.error(
             `maple-proxy crashed ${MAX_RESTART_ATTEMPTS} times, giving up. ` +
@@ -209,7 +209,7 @@ export async function startProxy(
         if (!exited) {
           child.kill("SIGKILL");
         }
-      }, 3000);
+      }, 3000).unref();
     },
   };
 }

--- a/openclaw-plugin/lib/process.ts
+++ b/openclaw-plugin/lib/process.ts
@@ -1,0 +1,105 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import net from "node:net";
+
+export interface ProxyConfig {
+  binaryPath: string;
+  apiKey: string;
+  port?: number;
+  backendUrl?: string;
+  debug?: boolean;
+}
+
+export interface RunningProxy {
+  process: ChildProcess;
+  port: number;
+  kill: () => void;
+}
+
+async function findFreePort(preferred: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(preferred, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : preferred;
+      server.close(() => resolve(port));
+    });
+    server.on("error", () => {
+      // Preferred port busy, let OS pick one
+      const fallback = net.createServer();
+      fallback.listen(0, "127.0.0.1", () => {
+        const addr = fallback.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        fallback.close(() => resolve(port));
+      });
+      fallback.on("error", reject);
+    });
+  });
+}
+
+async function waitForHealth(port: number, timeoutMs: number = 10000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      if (res.ok) return;
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`maple-proxy did not become healthy within ${timeoutMs}ms`);
+}
+
+export async function startProxy(
+  config: ProxyConfig,
+  logger: { info: (msg: string) => void; error: (msg: string) => void }
+): Promise<RunningProxy> {
+  const port = await findFreePort(config.port ?? 8080);
+
+  const env: Record<string, string> = {
+    ...process.env as Record<string, string>,
+    MAPLE_HOST: "127.0.0.1",
+    MAPLE_PORT: String(port),
+    MAPLE_API_KEY: config.apiKey,
+  };
+
+  if (config.backendUrl) {
+    env.MAPLE_BACKEND_URL = config.backendUrl;
+  }
+  if (config.debug) {
+    env.MAPLE_DEBUG = "true";
+  }
+
+  const child = spawn(config.binaryPath, [], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: false,
+  });
+
+  child.stdout?.on("data", (data: Buffer) => {
+    logger.info(`[maple-proxy] ${data.toString().trim()}`);
+  });
+
+  child.stderr?.on("data", (data: Buffer) => {
+    logger.error(`[maple-proxy] ${data.toString().trim()}`);
+  });
+
+  child.on("exit", (code) => {
+    if (code !== null && code !== 0) {
+      logger.error(`maple-proxy exited with code ${code}`);
+    }
+  });
+
+  await waitForHealth(port);
+  logger.info(`maple-proxy running on http://127.0.0.1:${port}`);
+
+  return {
+    process: child,
+    port,
+    kill: () => {
+      if (!child.killed) {
+        child.kill("SIGTERM");
+      }
+    },
+  };
+}

--- a/openclaw-plugin/lib/process.ts
+++ b/openclaw-plugin/lib/process.ts
@@ -116,7 +116,7 @@ export async function startProxy(
   const setupCrashRecovery = (proc: ChildProcess) => {
     proc.on("exit", (code, signal) => {
       if (stopped) return;
-      if (signal === "SIGINT" || signal === "SIGTERM") return;
+      if (signal === "SIGINT" || signal === "SIGTERM" || signal === "SIGKILL") return;
 
       const crashed =
         (code !== null && code !== 0) ||

--- a/openclaw-plugin/lib/process.ts
+++ b/openclaw-plugin/lib/process.ts
@@ -15,7 +15,7 @@ export interface ProxyConfig {
 }
 
 export interface RunningProxy {
-  process: ChildProcess;
+  readonly process: ChildProcess;
   port: number;
   version: string;
   kill: () => void;
@@ -193,7 +193,9 @@ export async function startProxy(
   logger.info(`maple-proxy running on http://127.0.0.1:${port}`);
 
   return {
-    process: child,
+    get process() {
+      return child;
+    },
     port,
     version,
     kill: () => {
@@ -202,7 +204,7 @@ export async function startProxy(
       child.kill("SIGINT");
       setTimeout(() => {
         if (!exited) {
-          child.kill("SIGTERM");
+          child.kill("SIGKILL");
         }
       }, 3000);
     },

--- a/openclaw-plugin/lib/process.ts
+++ b/openclaw-plugin/lib/process.ts
@@ -149,6 +149,9 @@ export async function startProxy(
               logger.error(
                 `Failed to restart maple-proxy: ${err instanceof Error ? err.message : err}`
               );
+              if (!child.killed) {
+                child.kill("SIGKILL");
+              }
             }
           }, delay);
         } else {

--- a/openclaw-plugin/lib/process.ts
+++ b/openclaw-plugin/lib/process.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import net from "node:net";
 
-const DEFAULT_PORT = 8000;
+const DEFAULT_PORT = 8787;
 const HEALTH_TIMEOUT_MS = 10000;
 const MAX_RESTART_ATTEMPTS = 3;
 const RESTART_BACKOFF_MS = 2000;

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "maple-proxy-openclaw-plugin",
+  "name": "Maple Proxy",
+  "description": "Run Maple TEE-backed AI models locally via maple-proxy",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": { "type": "string" },
+      "port": { "type": "number" },
+      "backendUrl": { "type": "string" },
+      "debug": { "type": "boolean" }
+    },
+    "required": ["apiKey"]
+  },
+  "uiHints": {
+    "apiKey": { "label": "Maple API Key", "sensitive": true },
+    "port": { "label": "Local Port", "placeholder": "8080" },
+    "backendUrl": { "label": "Backend URL", "placeholder": "https://enclave.trymaple.ai" },
+    "debug": { "label": "Debug Logging" }
+  },
+  "skills": ["./skills/maple-proxy-skill"]
+}

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -10,7 +10,8 @@
       "apiKey": { "type": "string" },
       "port": { "type": "number" },
       "backendUrl": { "type": "string" },
-      "debug": { "type": "boolean" }
+      "debug": { "type": "boolean" },
+      "version": { "type": "string" }
     },
     "required": ["apiKey"]
   },
@@ -18,7 +19,8 @@
     "apiKey": { "label": "Maple API Key", "sensitive": true },
     "port": { "label": "Local Port", "placeholder": "8080" },
     "backendUrl": { "label": "Backend URL", "placeholder": "https://enclave.trymaple.ai" },
-    "debug": { "label": "Debug Logging" }
+    "debug": { "label": "Debug Logging" },
+    "version": { "label": "Binary Version", "placeholder": "latest" }
   },
   "skills": ["./skills/maple-proxy-skill"]
 }

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -17,7 +17,7 @@
   },
   "uiHints": {
     "apiKey": { "label": "Maple API Key", "sensitive": true },
-    "port": { "label": "Local Port", "placeholder": "8000" },
+    "port": { "label": "Local Port", "placeholder": "8787" },
     "backendUrl": { "label": "Backend URL", "placeholder": "https://enclave.trymaple.ai" },
     "debug": { "label": "Debug Logging" },
     "version": { "label": "Binary Version", "placeholder": "latest" }

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "maple-proxy-openclaw-plugin",
+  "id": "maple-openclaw-plugin",
   "name": "Maple Proxy",
   "description": "Run Maple TEE-backed AI models locally via maple-proxy",
   "version": "0.1.0",
@@ -17,7 +17,7 @@
   },
   "uiHints": {
     "apiKey": { "label": "Maple API Key", "sensitive": true },
-    "port": { "label": "Local Port", "placeholder": "8080" },
+    "port": { "label": "Local Port", "placeholder": "8000" },
     "backendUrl": { "label": "Backend URL", "placeholder": "https://enclave.trymaple.ai" },
     "debug": { "label": "Debug Logging" },
     "version": { "label": "Binary Version", "placeholder": "latest" }

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@opensecret/maple-proxy-openclaw-plugin",
+  "name": "@opensecret/maple-openclaw-plugin",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@opensecret/maple-proxy-openclaw-plugin",
+      "name": "@opensecret/maple-openclaw-plugin",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "@opensecret/maple-proxy-openclaw-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@opensecret/maple-proxy-openclaw-plugin",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/openclaw-plugin/package-lock.json
+++ b/openclaw-plugin/package-lock.json
@@ -11,6 +11,14 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.7.0"
+      },
+      "peerDependencies": {
+        "openclaw": ">=2026.1.0"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/node": {

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit",
-    "test": "echo \"no tests yet\"",
+    "test": "tsc && node --test dist/lib/downloader.test.js",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/maple-openclaw-plugin",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
   "type": "module",
   "license": "MIT",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/maple-openclaw-plugin",
-  "version": "0.1.0-beta.4",
+  "version": "0.1.0",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
   "type": "module",
   "license": "MIT",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@opensecret/maple-proxy-openclaw-plugin",
+  "name": "@opensecret/maple-openclaw-plugin",
   "version": "0.1.0",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
   "license": "MIT",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/maple-openclaw-plugin",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.2",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
   "type": "module",
   "license": "MIT",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@opensecret/maple-proxy-openclaw-plugin",
+  "version": "0.1.0",
+  "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenSecretCloud/maple-proxy",
+    "directory": "openclaw-plugin"
+  },
+  "openclaw": {
+    "extensions": ["./dist/index.js"]
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "skills",
+    "openclaw.plugin.json"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "lint": "tsc --noEmit",
+    "test": "echo \"no tests yet\"",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/maple-openclaw-plugin",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
   "type": "module",
   "license": "MIT",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/maple-openclaw-plugin",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.1",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
   "type": "module",
   "license": "MIT",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensecret/maple-openclaw-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
   "type": "module",
   "license": "MIT",

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@opensecret/maple-openclaw-plugin",
   "version": "0.1.0",
   "description": "OpenClaw plugin that runs Maple TEE-backed AI models via maple-proxy",
+  "type": "module",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,20 +10,26 @@
     "directory": "openclaw-plugin"
   },
   "openclaw": {
-    "extensions": ["./dist/index.js"]
+    "extensions": ["./index.ts"]
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "files": [
-    "dist",
+    "index.ts",
+    "lib",
     "skills",
     "openclaw.plugin.json"
   ],
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit",
-    "test": "tsc && node --test dist/lib/downloader.test.js",
-    "prepublishOnly": "npm run build"
+    "test": "tsc && node --test dist/lib/downloader.test.js"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.1.0"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "typescript": "^5.7.0",

--- a/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
+++ b/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
@@ -55,7 +55,7 @@ To configure memory search with maple-proxy embeddings, add this to your `opencl
         "model": "nomic-embed-text",
         "remote": {
           "baseUrl": "http://127.0.0.1:8000/v1/",
-          "apiKey": "maple-local"
+          "apiKey": "YOUR_MAPLE_API_KEY"
         }
       }
     }
@@ -64,7 +64,7 @@ To configure memory search with maple-proxy embeddings, add this to your `opencl
 ```
 
 Notes:
-- The `apiKey` value can be anything (e.g., `"maple-local"`) since maple-proxy uses the plugin-configured API key for backend auth
+- Use the same Maple API key you configured in the plugin config -- maple-proxy forwards the `Authorization: Bearer` header to the TEE backend for authentication
 - If you changed the plugin port, update the `baseUrl` accordingly
 - This replaces the need for a separate OpenAI, Gemini, or Voyage API key for embeddings
 - Compatible with OpenClaw's hybrid search (BM25 + vector), session memory indexing, and embedding cache

--- a/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
+++ b/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
@@ -123,3 +123,7 @@ The default port is 8787. To change it:
 ```
 
 If you change the port, update your `models.providers.maple.baseUrl` and `memorySearch.remote.baseUrl` to match.
+
+## Configuration Changes
+
+Plugin config changes (port, API key, backend URL) require a full gateway restart to take effect. Model and provider config changes hot-apply without a restart.

--- a/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
+++ b/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
@@ -8,27 +8,23 @@ metadata: {"openclaw": {"requires": {"config": ["plugins.entries.maple-openclaw-
 
 The maple-openclaw-plugin manages a local OpenAI-compatible proxy server that forwards requests to Maple's TEE (Trusted Execution Environment) backend. All AI inference runs inside secure enclaves.
 
-## Provider Setup (Recommended)
+## Setup
 
-maple-proxy runs on port **8000** by default -- the same as vLLM. OpenClaw can auto-discover it as a vLLM-compatible provider. To enable:
+### 1. Add the Maple provider
 
-1. Set `VLLM_API_KEY` to any value (e.g., `"maple-local"`)
-2. Do **not** define an explicit `models.providers.vllm` entry
-3. OpenClaw will discover models at `http://127.0.0.1:8000/v1/models`
-4. Use models as `vllm/<model-id>` (e.g., `vllm/llama3-3-70b`)
-
-Or configure explicitly under `models.providers`:
+Add a `maple` provider to your `openclaw.json` with your Maple API key and the models you want to use. maple-proxy runs on port **8787** by default.
 
 ```json
 {
   "models": {
     "providers": {
       "maple": {
-        "baseUrl": "http://127.0.0.1:8000/v1",
-        "apiKey": "maple-local",
+        "baseUrl": "http://127.0.0.1:8787/v1",
+        "apiKey": "YOUR_MAPLE_API_KEY",
         "api": "openai-completions",
         "models": [
-          { "id": "llama3-3-70b", "name": "Llama 3.3 70B" }
+          { "id": "kimi-k2-5", "name": "Kimi K2.5 (recommended)" },
+          { "id": "llama-3.3-70b", "name": "Llama 3.3 70B" }
         ]
       }
     }
@@ -36,15 +32,53 @@ Or configure explicitly under `models.providers`:
 }
 ```
 
+Use the same Maple API key you configured in the plugin config -- maple-proxy forwards the `Authorization: Bearer` header to the TEE backend for authentication.
+
+To discover available models, use the `maple_proxy_status` tool or call `GET http://127.0.0.1:8787/v1/models` directly.
+
+### 2. Add models to the allowlist
+
+If you have an `agents.defaults.models` section in your config, you must add the maple models you want to use. If you don't have this section at all, skip this step -- all models are allowed by default.
+
+Add each model you want to use as `maple/<model-id>`. Check available models via `GET http://127.0.0.1:8787/v1/models` or the `maple_proxy_status` tool.
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "models": {
+        "maple/kimi-k2-5": {},
+        "maple/llama-3.3-70b": {}
+      }
+    }
+  }
+}
+```
+
+### 3. Restart the gateway
+
+Restart the OpenClaw gateway to pick up the new provider and model config.
+
+## Using Maple Models
+
+Use maple models by prefixing with `maple/`:
+
+- `maple/kimi-k2-5` (recommended)
+- `maple/llama-3.3-70b`
+
+To spawn a subagent on a Maple model:
+
+```
+Use sessions_spawn with model: "maple/kimi-k2-5" to run tasks on Maple TEE models.
+```
+
 ## Status Tool
 
-Use the `maple_proxy_status` tool to check if the proxy is running, which port it is on, and its health status.
+Use the `maple_proxy_status` tool to check if the proxy is running, which port it is on, its health status, and the available models endpoint.
 
 ## Embeddings & Memory Search
 
 maple-proxy serves an OpenAI-compatible embeddings endpoint using the `nomic-embed-text` model. You can use this for OpenClaw's memory search so that embeddings are generated inside the TEE -- no cloud embedding provider needed.
-
-To configure memory search with maple-proxy embeddings, add this to your `openclaw.json`:
 
 ```json
 {
@@ -54,7 +88,7 @@ To configure memory search with maple-proxy embeddings, add this to your `opencl
         "provider": "openai",
         "model": "nomic-embed-text",
         "remote": {
-          "baseUrl": "http://127.0.0.1:8000/v1/",
+          "baseUrl": "http://127.0.0.1:8787/v1/",
           "apiKey": "YOUR_MAPLE_API_KEY"
         }
       }
@@ -63,37 +97,29 @@ To configure memory search with maple-proxy embeddings, add this to your `opencl
 }
 ```
 
-Notes:
-- Use the same Maple API key you configured in the plugin config -- maple-proxy forwards the `Authorization: Bearer` header to the TEE backend for authentication
-- If you changed the plugin port, update the `baseUrl` accordingly
-- This replaces the need for a separate OpenAI, Gemini, or Voyage API key for embeddings
-- Compatible with OpenClaw's hybrid search (BM25 + vector), session memory indexing, and embedding cache
+Use the same Maple API key here. This replaces the need for a separate OpenAI, Gemini, or Voyage API key for embeddings. Compatible with OpenClaw's hybrid search (BM25 + vector), session memory indexing, and embedding cache.
 
 ## Direct API Access
 
-- `GET http://127.0.0.1:8000/v1/models` - List available models
-- `POST http://127.0.0.1:8000/v1/chat/completions` - Chat completions (streaming and non-streaming)
-- `POST http://127.0.0.1:8000/v1/embeddings` - Generate embeddings (model: `nomic-embed-text`)
-- `GET http://127.0.0.1:8000/health` - Health check
+- `GET http://127.0.0.1:8787/v1/models` - List available models
+- `POST http://127.0.0.1:8787/v1/chat/completions` - Chat completions (streaming and non-streaming)
+- `POST http://127.0.0.1:8787/v1/embeddings` - Generate embeddings (model: `nomic-embed-text`)
+- `GET http://127.0.0.1:8787/health` - Health check
 
 ## Port Override
 
-The default port is 8000. If something else uses port 8000, override it in plugin config:
+The default port is 8787. To change it:
 
 ```json
 {
   "plugins": {
     "entries": {
       "maple-openclaw-plugin": {
-        "config": { "port": 8200 }
+        "config": { "port": 9000 }
       }
     }
   }
 }
 ```
 
-If you change the port, update your `models.providers` base URL to match.
-
-## Authentication
-
-Authentication is handled automatically by the plugin via the configured API key. No per-request auth headers are needed from the agent.
+If you change the port, update your `models.providers.maple.baseUrl` and `memorySearch.remote.baseUrl` to match.

--- a/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
+++ b/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
@@ -1,21 +1,69 @@
 ---
 name: maple-proxy-skill
 description: Use Maple TEE-backed AI models via the local maple-proxy
-metadata: {"openclaw": {"requires": {"config": ["plugins.entries.maple-proxy-openclaw-plugin.enabled"]}, "primaryEnv": "MAPLE_API_KEY", "emoji": "🍁"}}
+metadata: {"openclaw": {"requires": {"config": ["plugins.entries.maple-openclaw-plugin.enabled"]}, "primaryEnv": "MAPLE_API_KEY", "emoji": "🍁"}}
 ---
 
 # Maple Proxy
 
-The maple-proxy plugin manages a local OpenAI-compatible proxy server that forwards requests to Maple's TEE (Trusted Execution Environment) backend. All AI inference runs inside secure enclaves.
+The maple-openclaw-plugin manages a local OpenAI-compatible proxy server that forwards requests to Maple's TEE (Trusted Execution Environment) backend. All AI inference runs inside secure enclaves.
 
-## Available Endpoints
+## Provider Setup (Recommended)
 
-- `GET http://127.0.0.1:8080/v1/models` - List available models
-- `POST http://127.0.0.1:8080/v1/chat/completions` - Chat completions (streaming and non-streaming)
-- `GET http://127.0.0.1:8080/health` - Health check
+maple-proxy runs on port **8000** by default -- the same as vLLM. OpenClaw can auto-discover it as a vLLM-compatible provider. To enable:
 
-## Usage
+1. Set `VLLM_API_KEY` to any value (e.g., `"maple-local"`)
+2. Do **not** define an explicit `models.providers.vllm` entry
+3. OpenClaw will discover models at `http://127.0.0.1:8000/v1/models`
+4. Use models as `vllm/<model-id>` (e.g., `vllm/llama3-3-70b`)
 
-The proxy is OpenAI-compatible. Use any OpenAI client library pointed at `http://127.0.0.1:8080`. The port may differ if 8080 was busy -- check the plugin logs for the actual port.
+Or configure explicitly under `models.providers`:
 
-Authentication is handled automatically by the plugin via the configured API key.
+```json
+{
+  "models": {
+    "providers": {
+      "maple": {
+        "baseUrl": "http://127.0.0.1:8000/v1",
+        "apiKey": "maple-local",
+        "api": "openai-completions",
+        "models": [
+          { "id": "llama3-3-70b", "name": "Llama 3.3 70B" }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Status Tool
+
+Use the `maple_proxy_status` tool to check if the proxy is running, which port it is on, and its health status.
+
+## Direct API Access
+
+- `GET http://127.0.0.1:8000/v1/models` - List available models
+- `POST http://127.0.0.1:8000/v1/chat/completions` - Chat completions (streaming and non-streaming)
+- `GET http://127.0.0.1:8000/health` - Health check
+
+## Port Override
+
+The default port is 8000. If something else uses port 8000, override it in plugin config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "maple-openclaw-plugin": {
+        "config": { "port": 8200 }
+      }
+    }
+  }
+}
+```
+
+If you change the port, update your `models.providers` base URL to match.
+
+## Authentication
+
+Authentication is handled automatically by the plugin via the configured API key. No per-request auth headers are needed from the agent.

--- a/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
+++ b/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
@@ -24,7 +24,10 @@ Add a `maple` provider to your `openclaw.json` with your Maple API key and the m
         "api": "openai-completions",
         "models": [
           { "id": "kimi-k2-5", "name": "Kimi K2.5 (recommended)" },
-          { "id": "llama-3.3-70b", "name": "Llama 3.3 70B" }
+          { "id": "deepseek-r1-0528", "name": "DeepSeek R1" },
+          { "id": "gpt-oss-120b", "name": "GPT-OSS 120B" },
+          { "id": "llama-3.3-70b", "name": "Llama 3.3 70B" },
+          { "id": "qwen3-vl-30b", "name": "Qwen3 VL 30B" }
         ]
       }
     }
@@ -48,7 +51,10 @@ Add each model you want to use as `maple/<model-id>`. Check available models via
     "defaults": {
       "models": {
         "maple/kimi-k2-5": {},
-        "maple/llama-3.3-70b": {}
+        "maple/deepseek-r1-0528": {},
+        "maple/gpt-oss-120b": {},
+        "maple/llama-3.3-70b": {},
+        "maple/qwen3-vl-30b": {}
       }
     }
   }
@@ -64,7 +70,10 @@ Restart the OpenClaw gateway to pick up the new provider and model config.
 Use maple models by prefixing with `maple/`:
 
 - `maple/kimi-k2-5` (recommended)
+- `maple/deepseek-r1-0528`
+- `maple/gpt-oss-120b`
 - `maple/llama-3.3-70b`
+- `maple/qwen3-vl-30b`
 
 To spawn a subagent on a Maple model:
 

--- a/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
+++ b/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: maple-proxy-skill
+description: Use Maple TEE-backed AI models via the local maple-proxy
+metadata: {"openclaw": {"requires": {"config": ["plugins.entries.maple-proxy-openclaw-plugin.enabled"]}, "primaryEnv": "MAPLE_API_KEY", "emoji": "🍁"}}
+---
+
+# Maple Proxy
+
+The maple-proxy plugin manages a local OpenAI-compatible proxy server that forwards requests to Maple's TEE (Trusted Execution Environment) backend. All AI inference runs inside secure enclaves.
+
+## Available Endpoints
+
+- `GET http://127.0.0.1:8080/v1/models` - List available models
+- `POST http://127.0.0.1:8080/v1/chat/completions` - Chat completions (streaming and non-streaming)
+- `GET http://127.0.0.1:8080/health` - Health check
+
+## Usage
+
+The proxy is OpenAI-compatible. Use any OpenAI client library pointed at `http://127.0.0.1:8080`. The port may differ if 8080 was busy -- check the plugin logs for the actual port.
+
+Authentication is handled automatically by the plugin via the configured API key.

--- a/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
+++ b/openclaw-plugin/skills/maple-proxy-skill/SKILL.md
@@ -40,10 +40,40 @@ Or configure explicitly under `models.providers`:
 
 Use the `maple_proxy_status` tool to check if the proxy is running, which port it is on, and its health status.
 
+## Embeddings & Memory Search
+
+maple-proxy serves an OpenAI-compatible embeddings endpoint using the `nomic-embed-text` model. You can use this for OpenClaw's memory search so that embeddings are generated inside the TEE -- no cloud embedding provider needed.
+
+To configure memory search with maple-proxy embeddings, add this to your `openclaw.json`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "memorySearch": {
+        "provider": "openai",
+        "model": "nomic-embed-text",
+        "remote": {
+          "baseUrl": "http://127.0.0.1:8000/v1/",
+          "apiKey": "maple-local"
+        }
+      }
+    }
+  }
+}
+```
+
+Notes:
+- The `apiKey` value can be anything (e.g., `"maple-local"`) since maple-proxy uses the plugin-configured API key for backend auth
+- If you changed the plugin port, update the `baseUrl` accordingly
+- This replaces the need for a separate OpenAI, Gemini, or Voyage API key for embeddings
+- Compatible with OpenClaw's hybrid search (BM25 + vector), session memory indexing, and embedding cache
+
 ## Direct API Access
 
 - `GET http://127.0.0.1:8000/v1/models` - List available models
 - `POST http://127.0.0.1:8000/v1/chat/completions` - Chat completions (streaming and non-streaming)
+- `POST http://127.0.0.1:8000/v1/embeddings` - Generate embeddings (model: `nomic-embed-text`)
 - `GET http://127.0.0.1:8000/health` - Health check
 
 ## Port Override

--- a/openclaw-plugin/tsconfig.json
+++ b/openclaw-plugin/tsconfig.json
@@ -11,6 +11,6 @@
     "declaration": true,
     "sourceMap": true
   },
-  "include": ["index.ts", "lib/**/*.ts"],
+  "include": ["index.ts", "lib/**/*.ts", "lib/**/*.test.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/openclaw-plugin/tsconfig.json
+++ b/openclaw-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds an OpenClaw plugin (`@opensecret/maple-proxy-openclaw-plugin`) that automatically downloads, manages, and runs the `maple-proxy` binary as a background service within OpenClaw. Users install the plugin, provide an API key, and get immediate access to Maple's TEE-backed AI models -- no manual setup needed.

Closes #12

## What's included

### `openclaw-plugin/` directory (new)
- **`index.ts`** -- Plugin entry point; registers a background service that starts/stops `maple-proxy`
- **`lib/platform.ts`** -- OS/arch detection, maps to the correct GitHub Release artifact name
- **`lib/downloader.ts`** -- Downloads the binary from GitHub Releases, verifies SHA256 checksums, extracts and caches in `~/.openclaw/tools/maple-proxy/`
- **`lib/process.ts`** -- Spawns `maple-proxy` as a child process, finds free ports, waits for health check
- **`openclaw.plugin.json`** -- Plugin manifest with config schema (`apiKey` required, `port`/`backendUrl`/`debug` optional) and UI hints
- **`package.json`** -- npm package `@opensecret/maple-proxy-openclaw-plugin`
- **`skills/maple-proxy-skill/SKILL.md`** -- AgentSkills-compatible skill, gated on plugin being enabled

### Dev tooling updates
- **`flake.nix`** -- Added `nodejs_22` to `commonInputs` so TypeScript plugin dev works in the Nix devShell
- **`justfile`** -- Added `plugin-install`, `plugin-build`, `plugin-lint`, `plugin-test`, `check-all`, `plugin-link`, `plugin-pack`, `plugin-publish` commands

## Naming convention

`maple-proxy` is reserved for the Rust binary. All plugin/skill names use a `maple-proxy-` prefix:
- Plugin id: `maple-proxy-openclaw-plugin`
- npm package: `@opensecret/maple-proxy-openclaw-plugin`
- Skill name: `maple-proxy-skill`

## User experience

```bash
openclaw plugins install @opensecret/maple-proxy-openclaw-plugin
```

Then in `openclaw.json`:
```json
{
  "plugins": {
    "entries": {
      "maple-proxy-openclaw-plugin": {
        "enabled": true,
        "config": { "apiKey": "sk-..." }
      }
    }
  }
}
```

Restart the gateway -- the plugin downloads the binary, starts it, and the skill becomes available to the agent.

## No changes to Rust source

The `src/` directory is completely untouched. The existing release CI (`release.yml`) already builds binaries for all 4 platforms that the plugin downloads from.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Maple Proxy plugin now available for OpenClaw, enabling integration with Maple TEE-backed AI models.
  * New `maple_proxy_status` tool to monitor proxy health and system metrics.
  * Plugin auto-manages binary downloads, versioning, and platform compatibility.

* **Documentation**
  * Added comprehensive plugin setup, configuration, and troubleshooting guides.
  * Included skill documentation for Maple model integration with memory search capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->