### PR TITLE
Cache OpenSecret clients per API key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +598,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1024,6 +1044,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1442,6 +1468,7 @@ dependencies = [
  "axum",
  "axum-test",
  "clap",
+ "dashmap",
  "dotenvy",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ opensecret = "3.1.1"
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }
-tokio = { version = "1.47", features = ["net", "rt-multi-thread", "macros"] }
+tokio = { version = "1.47", features = ["net", "rt-multi-thread", "macros", "sync"] }
 tower = { version = "0.5.2", features = ["full"] }
 tower-http = { version = "0.6.6", features = ["cors", "trace"] }
 
@@ -41,6 +41,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 dotenvy = "0.15"
 
 # Utilities
+dashmap = "6.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 anyhow = "1.0"

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -5,22 +5,58 @@ use axum::{
     response::{IntoResponse, Response, Sse},
     Json,
 };
+use dashmap::DashMap;
 use futures::Stream;
 use opensecret::{
     ChatCompletionChunk, ChatCompletionRequest, EmbeddingRequest, EmbeddingResponse,
     ModelsResponse, OpenSecretClient, Result as OpenSecretResult,
 };
 use std::{convert::Infallible, sync::Arc};
+use tokio::sync::OnceCell;
 use tracing::{debug, error};
 
 #[derive(Clone)]
 pub struct ProxyState {
     pub config: Config,
+    clients: DashMap<String, Arc<OnceCell<Arc<OpenSecretClient>>>>,
 }
 
 impl ProxyState {
     pub fn new(config: Config) -> Self {
-        Self { config }
+        Self {
+            config,
+            clients: DashMap::new(),
+        }
+    }
+
+    fn client_cell_for_api_key(&self, api_key: &str) -> Arc<OnceCell<Arc<OpenSecretClient>>> {
+        self.clients
+            .entry(api_key.to_string())
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone()
+    }
+
+    async fn client_for_api_key(
+        &self,
+        api_key: &str,
+    ) -> Result<Arc<OpenSecretClient>, OpenAIError> {
+        let client_cell = self.client_cell_for_api_key(api_key);
+        let backend_url = self.config.backend_url.clone();
+        let api_key = api_key.to_string();
+
+        let client = client_cell
+            .get_or_try_init(|| async move {
+                debug!(
+                    "Creating OpenSecret client for API key: {}...",
+                    &api_key[..8.min(api_key.len())]
+                );
+                create_client_with_auth(&backend_url, &api_key)
+                    .await
+                    .map(Arc::new)
+            })
+            .await?;
+
+        Ok(Arc::clone(client))
     }
 }
 
@@ -82,7 +118,8 @@ pub async fn list_models(
         &api_key[..8.min(api_key.len())]
     );
 
-    let client = create_client_with_auth(&state.config.backend_url, &api_key)
+    let client = state
+        .client_for_api_key(&api_key)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(e)))?;
 
@@ -115,7 +152,8 @@ pub async fn create_chat_completion(
         request.stream.unwrap_or(false)
     );
 
-    let client = create_client_with_auth(&state.config.backend_url, &api_key)
+    let client = state
+        .client_for_api_key(&api_key)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(e)))?;
 
@@ -209,7 +247,8 @@ pub async fn create_embeddings(
 
     debug!("Embeddings request for model: {}", request.model);
 
-    let client = create_client_with_auth(&state.config.backend_url, &api_key)
+    let client = state
+        .client_for_api_key(&api_key)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(e)))?;
 
@@ -229,4 +268,42 @@ pub async fn create_embeddings(
         response.data.len()
     );
     Ok(Json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> Config {
+        Config {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            backend_url: "http://localhost:3000".to_string(),
+            default_api_key: None,
+            debug: false,
+            enable_cors: false,
+        }
+    }
+
+    #[test]
+    fn reuses_client_cell_for_same_api_key() {
+        let state = ProxyState::new(test_config());
+
+        let first = state.client_cell_for_api_key("key-a");
+        let second = state.client_cell_for_api_key("key-a");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(state.clients.len(), 1);
+    }
+
+    #[test]
+    fn keeps_client_cells_separate_by_api_key() {
+        let state = ProxyState::new(test_config());
+
+        let first = state.client_cell_for_api_key("key-a");
+        let second = state.client_cell_for_api_key("key-b");
+
+        assert!(!Arc::ptr_eq(&first, &second));
+        assert_eq!(state.clients.len(), 2);
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -11,14 +11,39 @@ use opensecret::{
     ChatCompletionChunk, ChatCompletionRequest, EmbeddingRequest, EmbeddingResponse,
     ModelsResponse, OpenSecretClient, Result as OpenSecretResult,
 };
-use std::{convert::Infallible, sync::Arc};
+use std::{
+    convert::Infallible,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::sync::OnceCell;
 use tracing::{debug, error};
+
+const CLIENT_CACHE_MAX_ENTRIES: usize = 1024;
+const CLIENT_CACHE_ENTRY_TTL: Duration = Duration::from_secs(60 * 60);
+
+struct CachedClientEntry {
+    cell: OnceCell<Arc<OpenSecretClient>>,
+    created_at: Instant,
+}
+
+impl CachedClientEntry {
+    fn new(created_at: Instant) -> Self {
+        Self {
+            cell: OnceCell::new(),
+            created_at,
+        }
+    }
+
+    fn is_expired(&self, now: Instant) -> bool {
+        now.saturating_duration_since(self.created_at) >= CLIENT_CACHE_ENTRY_TTL
+    }
+}
 
 #[derive(Clone)]
 pub struct ProxyState {
     pub config: Config,
-    clients: DashMap<String, Arc<OnceCell<Arc<OpenSecretClient>>>>,
+    clients: DashMap<String, Arc<CachedClientEntry>>,
 }
 
 impl ProxyState {
@@ -29,10 +54,23 @@ impl ProxyState {
         }
     }
 
-    fn client_cell_for_api_key(&self, api_key: &str) -> Arc<OnceCell<Arc<OpenSecretClient>>> {
+    fn client_entry_for_api_key(&self, api_key: &str) -> Arc<CachedClientEntry> {
+        let now = Instant::now();
+
+        if let Some(entry) = self.clients.get(api_key) {
+            if !entry.is_expired(now) {
+                return Arc::clone(entry.value());
+            }
+        }
+
+        self.clients
+            .remove_if(api_key, |_, entry| entry.is_expired(now));
+        self.evict_expired_clients(now);
+        self.evict_oldest_client_if_needed();
+
         self.clients
             .entry(api_key.to_string())
-            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .or_insert_with(|| Arc::new(CachedClientEntry::new(now)))
             .clone()
     }
 
@@ -40,23 +78,56 @@ impl ProxyState {
         &self,
         api_key: &str,
     ) -> Result<Arc<OpenSecretClient>, OpenAIError> {
-        let client_cell = self.client_cell_for_api_key(api_key);
+        let cache_key = api_key.to_string();
+        let client_entry = self.client_entry_for_api_key(&cache_key);
         let backend_url = self.config.backend_url.clone();
-        let api_key = api_key.to_string();
+        let init_api_key = cache_key.clone();
 
-        let client = client_cell
+        let client = client_entry
+            .cell
             .get_or_try_init(|| async move {
                 debug!(
                     "Creating OpenSecret client for API key: {}...",
-                    &api_key[..8.min(api_key.len())]
+                    &init_api_key[..8.min(init_api_key.len())]
                 );
-                create_client_with_auth(&backend_url, &api_key)
+                create_client_with_auth(&backend_url, &init_api_key)
                     .await
                     .map(Arc::new)
             })
-            .await?;
+            .await;
 
-        Ok(Arc::clone(client))
+        match client {
+            Ok(client) => Ok(Arc::clone(client)),
+            Err(error) => {
+                self.remove_client_entry_if_same(&cache_key, &client_entry);
+                Err(error)
+            }
+        }
+    }
+
+    fn remove_client_entry_if_same(&self, api_key: &str, client_entry: &Arc<CachedClientEntry>) {
+        self.clients
+            .remove_if(api_key, |_, entry| Arc::ptr_eq(entry, client_entry));
+    }
+
+    fn evict_expired_clients(&self, now: Instant) {
+        self.clients.retain(|_, entry| !entry.is_expired(now));
+    }
+
+    fn evict_oldest_client_if_needed(&self) {
+        while self.clients.len() >= CLIENT_CACHE_MAX_ENTRIES {
+            let oldest_key = self
+                .clients
+                .iter()
+                .min_by_key(|entry| entry.value().created_at)
+                .map(|entry| entry.key().clone());
+
+            let Some(oldest_key) = oldest_key else {
+                break;
+            };
+
+            self.clients.remove(&oldest_key);
+        }
     }
 }
 
@@ -289,8 +360,8 @@ mod tests {
     fn reuses_client_cell_for_same_api_key() {
         let state = ProxyState::new(test_config());
 
-        let first = state.client_cell_for_api_key("key-a");
-        let second = state.client_cell_for_api_key("key-a");
+        let first = state.client_entry_for_api_key("key-a");
+        let second = state.client_entry_for_api_key("key-a");
 
         assert!(Arc::ptr_eq(&first, &second));
         assert_eq!(state.clients.len(), 1);
@@ -300,10 +371,52 @@ mod tests {
     fn keeps_client_cells_separate_by_api_key() {
         let state = ProxyState::new(test_config());
 
-        let first = state.client_cell_for_api_key("key-a");
-        let second = state.client_cell_for_api_key("key-b");
+        let first = state.client_entry_for_api_key("key-a");
+        let second = state.client_entry_for_api_key("key-b");
 
         assert!(!Arc::ptr_eq(&first, &second));
         assert_eq!(state.clients.len(), 2);
+    }
+
+    #[test]
+    fn evicts_old_client_cell_at_capacity() {
+        let state = ProxyState::new(test_config());
+
+        for index in 0..CLIENT_CACHE_MAX_ENTRIES {
+            state.client_entry_for_api_key(&format!("key-{}", index));
+        }
+
+        state.client_entry_for_api_key("new-key");
+
+        assert!(state.clients.contains_key("new-key"));
+        assert_eq!(state.clients.len(), CLIENT_CACHE_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn replaces_expired_client_cell() {
+        let state = ProxyState::new(test_config());
+        let expired_at = Instant::now()
+            .checked_sub(CLIENT_CACHE_ENTRY_TTL + Duration::from_secs(1))
+            .unwrap();
+        let expired = Arc::new(CachedClientEntry::new(expired_at));
+
+        state
+            .clients
+            .insert("key-a".to_string(), Arc::clone(&expired));
+
+        let fresh = state.client_entry_for_api_key("key-a");
+
+        assert!(!Arc::ptr_eq(&expired, &fresh));
+        assert_eq!(state.clients.len(), 1);
+    }
+
+    #[test]
+    fn removes_failed_initialization_cell() {
+        let state = ProxyState::new(test_config());
+        let entry = state.client_entry_for_api_key("key-a");
+
+        state.remove_client_entry_if_same("key-a", &entry);
+
+        assert!(!state.clients.contains_key("key-a"));
     }
 }


### PR DESCRIPTION
Closes #32.

Summary:
- Cache OpenSecret client initialization per API key in ProxyState.
- Use async OnceCell so concurrent first requests for the same key share one handshake.
- Add tests for per-key cache cell reuse and separation.

Tests:
- cargo test
- cargo clippy --all-targets -- -D warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Request handling now reuses backend clients per API key with cached entries, TTL-based expiry and capacity-based eviction to reduce repeated initialization.
* **Tests**
  * Added unit tests covering client reuse, isolation between API keys, eviction and replacement of expired or removed entries.
* **Chores**
  * Added dashmap dependency and expanded tokio feature set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->