### PR TITLE
feat: added MAPLE_MAX_PAYLOAD_SIZE env var to avoid 413 error

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::{net::SocketAddr, time::Duration};
 
 pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 300;
 pub const DEFAULT_STREAM_IDLE_TIMEOUT_SECS: u64 = 300;
+pub const DEFAULT_MAX_PAYLOAD_SIZE: usize = 2097152;
 
 #[derive(Parser, Debug, Clone)]
 #[command(name = "maple-proxy")]
@@ -54,6 +55,15 @@ pub struct Config {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     pub stream_idle_timeout_secs: u64,
+
+    /// Max payload size for the proxy requests
+    #[arg(
+        long,
+        env = "MAPLE_MAX_PAYLOAD_SIZE",
+        default_value_t = DEFAULT_MAX_PAYLOAD_SIZE,
+        value_parser = clap::value_parser!(usize)
+    )]
+    pub max_payload_size: usize,
 }
 
 impl Config {
@@ -81,6 +91,7 @@ impl Config {
             enable_cors: false,
             request_timeout_secs: DEFAULT_REQUEST_TIMEOUT_SECS,
             stream_idle_timeout_secs: DEFAULT_STREAM_IDLE_TIMEOUT_SECS,
+            max_payload_size: DEFAULT_MAX_PAYLOAD_SIZE
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use axum::{
     http::Method,
     routing::{get, post},
     Router,
+    extract::DefaultBodyLimit,
 };
 use std::sync::Arc;
 use tower::ServiceBuilder;
@@ -36,7 +37,7 @@ pub fn create_app(config: Config) -> Router {
                     .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
                     .on_response(DefaultOnResponse::new().level(Level::INFO)),
             ),
-        );
+        ).layer(DefaultBodyLimit::max(config.max_payload_size));
 
     // Add CORS if enabled
     if config.enable_cors {


### PR DESCRIPTION
There's a default body limit to 2MB in axum which was not configurable. This PR aims to be able to configure this default limit with an env variable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum request payload size limit with a 2MB default
  * Maximum payload size can be customized via environment variable configuration
  * Application now enforces request body size constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->