### PR TITLE
Document embeddings endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You should see:
    GET  /health              - Health check
    GET  /v1/models           - List available models
    POST /v1/chat/completions - Create chat completions (streaming)
+   POST /v1/embeddings       - Create embeddings
 ```
 
 ### API Endpoints
@@ -96,6 +97,17 @@ curl -N http://localhost:8080/v1/chat/completions \
 ```
 
 **Note:** Maple currently only supports streaming responses.
+
+#### Embeddings
+```bash
+curl http://localhost:8080/v1/embeddings \
+  -H "Authorization: Bearer YOUR_MAPLE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nomic-embed-text",
+    "input": "Generate an embedding for this text"
+  }'
+```
 
 ### Using as a Library
 
@@ -203,6 +215,15 @@ curl -N http://localhost:8080/v1/chat/completions \
     "model": "llama3-3-70b",
     "messages": [{"role": "user", "content": "Tell me a joke"}],
     "stream": true
+  }'
+
+# Embeddings
+curl http://localhost:8080/v1/embeddings \
+  -H "Authorization: Bearer YOUR_MAPLE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nomic-embed-text",
+    "input": "Generate an embedding for this text"
   }'
 ```
 
@@ -390,6 +411,7 @@ cargo test
 
 Maple Proxy supports all models available in the Maple/OpenSecret platform, including:
 - `llama3-3-70b` - Llama 3.3 70B parameter model
+- `nomic-embed-text` - Embedding model for `/v1/embeddings`
 - And many others - check `/v1/models` endpoint for current list
 
 ## 🔍 Troubleshooting

--- a/flake.nix
+++ b/flake.nix
@@ -10,17 +10,26 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         overlays = [ rust-overlay.overlays.default ];
         pkgs = import nixpkgs { inherit system overlays; };
-        
+
         # Try to use rust-toolchain.toml if it exists, otherwise use stable
-        rust = if builtins.pathExists ./rust-toolchain.toml
-          then pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml
-          else pkgs.rust-bin.stable.latest.default;
-        
+        rust =
+          if builtins.pathExists ./rust-toolchain.toml then
+            pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml
+          else
+            pkgs.rust-bin.stable.latest.default;
+
         commonInputs = with pkgs; [
           # Rust tooling
           rust
@@ -34,18 +43,17 @@
 
           # TypeScript / OpenClaw plugin
           nodejs_22
-          
+
           # Useful tools
           jq
           just
         ];
-        
+
         darwinOnlyInputs = with pkgs; [
           libiconv
-          darwin.apple_sdk.frameworks.Security
-          darwin.apple_sdk.frameworks.SystemConfiguration
+          apple-sdk
         ];
-        
+
         linuxOnlyInputs = with pkgs; [
           # Container runtime for Docker compatibility
           podman
@@ -53,35 +61,36 @@
           slirp4netns
           fuse-overlayfs
         ];
-        
-        allInputs = commonInputs
+
+        allInputs =
+          commonInputs
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinOnlyInputs
           ++ pkgs.lib.optionals pkgs.stdenv.isLinux linuxOnlyInputs;
       in
       {
         devShells.default = pkgs.mkShell {
           packages = allInputs;
-          
+
           shellHook = ''
             echo "Maple Proxy Development Environment"
             echo "-----------------------------------"
             echo "Rust toolchain: $(rustc --version)"
             echo ""
-            
+
             # Set up Rust environment variables
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
             export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
             export PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig
-            
+
             ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
               # macOS-specific setup
               export RUST_BACKTRACE=1
             ''}
-            
+
             ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
               # Linux-specific setup
               export RUST_BACKTRACE=1
-              
+
               # Podman as Docker replacement
               alias docker='podman'
               echo "Using 'podman' as an alias for 'docker'"

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ async fn main() -> anyhow::Result<()> {
     info!("   GET  /health              - Health check");
     info!("   GET  /v1/models           - List available models");
     info!("   POST /v1/chat/completions - Create chat completions (streaming & non-streaming)");
+    info!("   POST /v1/embeddings       - Create embeddings");
     info!("");
     info!("💡 Usage:");
     info!(


### PR DESCRIPTION
## Summary
- document the OpenAI-compatible `POST /v1/embeddings` endpoint in the README
- include `/v1/embeddings` in the startup endpoint list
- update the Darwin Nix dev shell to use the current `apple-sdk` package instead of removed legacy framework stubs

Closes #37

## Verification
- `nix develop -c bash -c 'cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings'`
- `nix develop -c cargo test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Embeddings endpoint (`POST /v1/embeddings`) is now available
  * Added support for `nomic-embed-text` model

* **Documentation**
  * Updated with embeddings endpoint documentation, usage examples, and client implementation guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->