### PR TITLE
Raise proxy request body limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use config::{Config, OpenAIError, OpenAIErrorDetails};
 use proxy::{create_chat_completion, create_embeddings, health_check, list_models, ProxyState};
 
 use axum::{
+    extract::DefaultBodyLimit,
     http::Method,
     routing::{get, post},
     Router,
@@ -16,6 +17,8 @@ use tower_http::{
     trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
 };
 use tracing::Level;
+
+pub const MAX_PROXY_REQUEST_BODY_BYTES: usize = 50 * 1024 * 1024;
 
 /// Create the Axum application with the given configuration
 pub fn create_app(config: Config) -> Router {
@@ -31,11 +34,13 @@ pub fn create_app(config: Config) -> Router {
         .route("/v1/embeddings", post(create_embeddings))
         .with_state(state)
         .layer(
-            ServiceBuilder::new().layer(
-                TraceLayer::new_for_http()
-                    .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
-                    .on_response(DefaultOnResponse::new().level(Level::INFO)),
-            ),
+            ServiceBuilder::new()
+                .layer(DefaultBodyLimit::max(MAX_PROXY_REQUEST_BODY_BYTES))
+                .layer(
+                    TraceLayer::new_for_http()
+                        .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
+                        .on_response(DefaultOnResponse::new().level(Level::INFO)),
+                ),
         );
 
     // Add CORS if enabled

--- a/tests/health_test.rs
+++ b/tests/health_test.rs
@@ -1,7 +1,7 @@
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use maple_proxy::{create_app, Config};
-use serde_json::Value;
+use maple_proxy::{create_app, Config, MAX_PROXY_REQUEST_BODY_BYTES};
+use serde_json::{json, Value};
 
 #[tokio::test]
 async fn test_health_check_endpoint() {
@@ -43,4 +43,34 @@ async fn test_root_health_check() {
 
     let json: Value = response.json();
     assert_eq!(json["status"], "ok");
+}
+
+#[tokio::test]
+async fn chat_completion_accepts_large_payloads_above_axum_default() {
+    assert_eq!(MAX_PROXY_REQUEST_BODY_BYTES, 50 * 1024 * 1024);
+
+    let config = Config::new(
+        "127.0.0.1".to_string(),
+        0,
+        "http://localhost:3000".to_string(),
+    );
+    let app = create_app(config);
+    let server = TestServer::new(app).unwrap();
+
+    let large_content = "x".repeat((2 * 1024 * 1024) + 1);
+    let response = server
+        .post("/v1/chat/completions")
+        .json(&json!({
+            "model": "quick",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": large_content
+                }
+            ],
+            "stream": false
+        }))
+        .await;
+
+    response.assert_status(StatusCode::UNAUTHORIZED);
 }


### PR DESCRIPTION
## Summary
- raise Maple Proxy's Axum JSON body limit to a fixed 50 MiB
- avoid adding a new env var or CLI setting for this local proxy concern
- add an integration test proving a >2 MiB chat payload reaches the handler instead of being rejected by Axum's default body limit

## Testing
- `nix develop -c just check`
- `opensecret-workspaces smoke maple-proxy-payload-limit`
- started Maple Proxy manually in the workspace with `MAPLE_BACKEND_URL=http://127.0.0.1:31401`
- `GET /health` through Maple Proxy returned `200`
- >2 MiB `POST /v1/chat/completions` through Maple Proxy returned `401` from the handler instead of `413`, which confirms the proxy body limit is no longer the blocker

Full local completion response testing still needs a smoother local OpenSecret API-key flow, so this PR intentionally stops at the proxy/body-limit smoke.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured maximum request body size limit to 50 MiB for proxy requests.

* **Tests**
  * Added test coverage for large request payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->