### PR TITLE
Update OpenSecret SDK to 3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,9 +1654,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opensecret"
-version = "3.1.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2782b2ff33589206bb6418bd7adbc1f064d3aef9e4a92aef93c41174ac5f686b"
+checksum = "92ce94955ead29ea33002f32d19b94420582e15e0b2c8b7c8e66e64dae6ff48a"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 # OpenSecret SDK 
-opensecret = "3.1.1"
+opensecret = "3.3.0"
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }


### PR DESCRIPTION
## Summary

- update the Rust OpenSecret SDK dependency from `3.1.1` to `3.3.0`
- refresh only the corresponding lockfile package version and checksum
- pick up float-array and base64 embedding response support from OpenSecretCloud/OpenSecret-SDK#86

## Why

Tinfoil and the OpenSecret backend already support `encoding_format: "base64"`. Maple Proxy failed while the older SDK attempted to deserialize every embedding as `Vec<f64>`. OpenSecret SDK 3.3.0 models the response as either a float vector or base64 string, so Maple Proxy can preserve and return either wire representation without proxy-layer conversion logic.

## Testing

- confirmed `opensecret 3.3.0` is published and downloadable from crates.io
- `cargo tree -i opensecret --locked` resolves `opensecret v3.3.0`
- `nix develop -c just check`
  - formatting passed
  - Clippy passed with warnings denied
  - 12 tests passed

Closes #40.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenSecret library to version 3.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->