### PR TITLE
Allow scheduled security audits to open issues

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      issues: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary

- grant `issues: write` to the non-PR `security_audit` job
- keep the workflow-wide and pull-request permissions read-only

## Why

The scheduled audit correctly detected a RustSec advisory, then `rustsec/audit-check` attempted to create a GitHub issue and failed with:

```
Resource not accessible by integration
```

The job already grants `checks: write`, but the action also needs `issues: write` when reporting a newly detected vulnerability. This permission is scoped only to the push/scheduled audit job; the pull-request audit continues to run with read-only repository permissions.

The vulnerable lockfile entry itself was fixed in #42. This follow-up ensures future scheduled findings can be reported successfully instead of failing during issue creation.

## Validation

- `actionlint .github/workflows/security.yml`
- `git diff --check`

A whole-repository `actionlint` pass also identified existing warnings in the Docker and release workflows; those are unrelated to this change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security audit workflow permissions to support reporting findings through issue tracking.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->