### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple-proxy"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple-proxy"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Lightweight OpenAI-compatible proxy server for Maple/OpenSecret TEE infrastructure"


### PR DESCRIPTION
## Summary

- bump the Maple Proxy crate and binary version from `0.1.10` to `0.1.11`
- update the matching root package entry in `Cargo.lock`

## Why

Prepare a patch release containing the OpenSecret SDK `3.3.0` upgrade for base64 embeddings and the `quinn-proto` security update merged in #42.

## Testing

- `nix develop -c just check`
  - formatting passed
  - clippy passed with warnings denied
  - all 12 tests passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->