### PR TITLE
Patch anyhow soundness advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asn1-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple-proxy"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple-proxy"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Lightweight OpenAI-compatible proxy server for Maple/OpenSecret TEE infrastructure"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ dotenvy = "0.15"
 dashmap = "6.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
-anyhow = "1.0"
+anyhow = "1.0.103"
 
 # HTTP types and headers
 http = "1.0"


### PR DESCRIPTION
## Summary

- require `anyhow >=1.0.103` and refresh the lockfile from `1.0.102`
- bump Maple Proxy from `0.1.11` to `0.1.12` in a separate commit
- eliminate `RUSTSEC-2026-0190` from both release artifacts and downstream locked dependency resolution

## Security impact

RustSec classifies this as an informational unsoundness warning affecting `anyhow::Error::downcast_mut`. Maple Proxy and OpenSecret SDK do not currently call the affected method, so no reachable production path was found, but the `v0.1.11` artifacts still contained the affected crate version. Raising the manifest floor ensures the fix is not limited to this repository lockfile.

Closes #45.

## Validation

- fresh `cargo audit` against advisory DB commit `e202964`: 0 vulnerabilities, 0 warnings
- `nix develop -c just check`
  - formatting passed
  - clippy passed with warnings denied
  - all 12 tests passed
- `nix develop -c cargo check --locked` after the version bump

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple-proxy/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the crate release version to 0.1.12.
  * Refreshed a dependency version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->