### PR TITLE
chore: bump maple-proxy to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple-proxy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1637,9 +1637,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opensecret"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f870bc0826a7091062aba70eeb82590691bcec630f35b7c2b60792f982fc66d8"
+checksum = "86d9a35e5dd1ee761d3449d9e2db722eb1ebbab0eef02d3bb8601fd6b23d6bd9"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple-proxy"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Lightweight OpenAI-compatible proxy server for Maple/OpenSecret TEE infrastructure"
@@ -29,7 +29,7 @@ path = "src/main.rs"
 
 [dependencies]
 # OpenSecret SDK
-opensecret = "3.6.0"
+opensecret = "3.6.1"
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add to your `Cargo.toml`:
 [dependencies]
 maple-proxy = { git = "https://github.com/opensecretcloud/maple-proxy" }
 # Or if published to crates.io:
-# maple-proxy = "0.3.0"
+# maple-proxy = "0.3.1"
 ```
 
 ## ⚙️ Configuration


### PR DESCRIPTION
## Summary
- bump `maple-proxy` from 0.3.0 to 0.3.1
- update the Rust OpenSecret SDK from 3.6.0 to 3.6.1
- keep the README installation version in sync

## Validation
- `cargo fmt --all -- --check`
- `cargo check --all-targets --all-features`
- `cargo test --all-features` (27 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo package --allow-dirty`
- `cargo audit` (no vulnerabilities reported)
- `cargo machete` (no unused dependencies)
- live local smoke: started `maple-proxy 0.3.1`; `GET /health` and `GET /` both returned HTTP 200

## Release
After merge, tag the merge commit as `v0.3.1` to publish the GitHub release binaries and GHCR images.