### PR TITLE
security: block compromised Rust crates

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,27 @@
+name: Rust supply-chain denylist
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: Known malicious crates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Check incident denylist
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          command: check bans
+          arguments: --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+[bans]
+# Emergency supply-chain containment for the August 2026 crates.io campaign.
+# Keep this check focused on known malicious packages; broader policy and
+# locked dependency enforcement are intentionally separate follow-up work.
+multiple-versions = "allow"
+wildcards = "allow"
+deny = [
+    # Legitimate crates whose malicious releases were removed. Block the
+    # compromised release and all later releases pending maintainer recovery.
+    { crate = "arrayref@>=0.3.10", reason = "Compromised release: RUSTSEC-2026-0260" },
+    { crate = "append-only-vec@>=0.1.9", reason = "Compromised release: RUSTSEC-2026-0262" },
+    { crate = "internment@>=0.8.7", reason = "Compromised release: RUSTSEC-2026-0266" },
+
+    # Campaign-associated malicious package names. Deny every version.
+    { crate = "arone", reason = "Malicious crate: RUSTSEC-2026-0259" },
+    { crate = "aronenao", reason = "Malicious crate: RUSTSEC-2026-0261" },
+    { crate = "tinymember", reason = "Malicious crate: RUSTSEC-2026-0263" },
+    { crate = "proc-macro-en", reason = "Malicious crate: RUSTSEC-2026-0264" },
+    { crate = "proc-macro1", reason = "Malicious crate: RUSTSEC-2026-0265" },
+    { crate = "aovine", reason = "Campaign-associated malicious crate removed from crates.io" },
+]


### PR DESCRIPTION
Adds a cargo-deny incident policy for the August 2026 crates.io supply-chain campaign and a pinned CI gate that checks known malicious package bans on pull requests and master pushes. The policy blocks the compromised arrayref, append-only-vec, and internment release ranges plus all versions of the campaign-only crate names.

This is intentionally the first containment layer only: it does not enable locked dependency or repository-wide advisory enforcement yet. The current Cargo graph passes the bans check, and the new workflow passes actionlint.