### PR TITLE
Security: enforce daily RustSec advisory checks

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,9 +1,11 @@
-name: Rust supply-chain denylist
+name: Rust supply-chain checks
 
 on:
   pull_request:
   push:
     branches: [master]
+  schedule:
+    - cron: "53 6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -11,7 +13,7 @@ permissions:
 
 jobs:
   cargo-deny:
-    name: Known malicious crates
+    name: RustSec advisories and malicious crates
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -20,8 +22,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check incident denylist
+      - name: Check RustSec advisories and incident denylist
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
-          command: check bans
+          command: check advisories bans
           arguments: --all-features --locked

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,11 @@
+[advisories]
+# Vulnerability and unsoundness advisories are blocking. Unmaintained-package
+# notices are tracked separately because they often require API migrations.
+unmaintained = "none"
+
 [bans]
 # Emergency supply-chain containment for the August 2026 crates.io campaign.
-# Keep this check focused on known malicious packages; broader policy and
-# locked dependency enforcement are intentionally separate follow-up work.
+# Keep these explicit package bans alongside the blocking RustSec checks.
 multiple-versions = "allow"
 wildcards = "allow"
 deny = [


### PR DESCRIPTION
## Summary

- upgrades patch-compatible RustSec-affected dependencies
- makes vulnerability and unsoundness advisories blocking in cargo-deny
- keeps the August 2026 malicious-crate denylist active
- adds a staggered daily supply-chain scan

## Validation

- `cargo deny --all-features --locked check advisories bans`
- repository-native compile/check coverage