### PR TITLE
security: enforce unsoundness advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [advisories]
 # Vulnerability and unsoundness advisories are blocking. Unmaintained-package
 # notices are tracked separately because they often require API migrations.
+unsound = "all"
 unmaintained = "none"
 
 [bans]


### PR DESCRIPTION
## Summary

- make cargo-deny block RustSec unsoundness advisories
- keep unmaintained-package notices non-blocking and separately tracked

## Validation

- cargo deny --all-features --locked check --config deny.toml advisories bans