### PR TITLE
chore: bump proxy to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple-proxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1637,9 +1637,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opensecret"
-version = "3.6.1"
+version = "3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d9a35e5dd1ee761d3449d9e2db722eb1ebbab0eef02d3bb8601fd6b23d6bd9"
+checksum = "3323b7adba9f171cc9277b7d51fb881e4a3f37c860eb533bcb0ae434bf4294e1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple-proxy"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["OpenSecret"]
 description = "Lightweight OpenAI-compatible proxy server for Maple/OpenSecret TEE infrastructure"
@@ -29,7 +29,7 @@ path = "src/main.rs"
 
 [dependencies]
 # OpenSecret SDK
-opensecret = "3.6.1"
+opensecret = "3.6.2"
 
 # Web server
 axum = { version = "0.8.4", features = ["http2", "macros"] }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add to your `Cargo.toml`:
 [dependencies]
 maple-proxy = { git = "https://github.com/opensecretcloud/maple-proxy" }
 # Or if published to crates.io:
-# maple-proxy = "0.3.1"
+# maple-proxy = "0.3.2"
 ```
 
 ## ⚙️ Configuration


### PR DESCRIPTION
## Summary

- bump maple-proxy from 0.3.1 to 0.3.2
- bump the published Rust opensecret SDK from 3.6.1 to 3.6.2
- keep Cargo.lock and the README installation example aligned

This lets API-key proxy traffic inherit the SDK-owned, single-attempt recovery for purged encrypted sessions while preserving the proxy request bytes and avoiding another retry layer in maple-proxy.

## Validation

- cargo fmt --all -- --check
- cargo check --locked --all-targets --all-features
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features: 27 passed
- cargo doc --locked --no-deps --all-features with warnings denied
- cargo package --locked: 12-file package boundary verified
- cargo publish --dry-run --locked verified maple-proxy@0.3.2
- cargo tree resolves opensecret@3.6.2
- git diff --check

The published opensecret@3.6.2 artifact was used for validation. This PR does not publish the crate or create the v0.3.2 release tag.